### PR TITLE
Support composer-manager by allowing to run custom script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,7 @@ install:
   - drupal-ti install
 
 before_script:
+  - drupal-ti --include scripts/test-include.sh
   - drupal-ti before_script
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ matrix:
   allow_failures:
     - php: hhvm
   exclude:
-  # Drupal-8 does not work on PHP 5.3.
+  # Drupal-8 does not work on PHP 5.3 or PHP 5.4.
     - php: 5.3
+      env: DRUPAL_TI_RUNNERS="test phpunit simpletest behat" DRUPAL_TI_ENVIRONMENT="drupal-8"
+    - php: 5.4
       env: DRUPAL_TI_RUNNERS="test phpunit simpletest behat" DRUPAL_TI_ENVIRONMENT="drupal-8"
 
   # Exclude single jobs from PHP 5.3 as well.

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ install:
   - drupal-ti install
 
 before_script:
-  - drupal-ti --include scripts/test-include.sh
+  - drupal-ti --include ../scripts/test-include.sh
   - drupal-ti before_script
 
 script:

--- a/drupal-ti
+++ b/drupal-ti
@@ -11,6 +11,9 @@ then
 	echo "Usage: $0 <cmd>" 1>&2
 	echo "" 1>&2
 	echo "- cmd: A valid travis-ci command, e.g. before-script, script, after-script." 1>&2
+	echo "" 1>&2
+	echo "       Use --include to include an arbitrary script within the drupal_ti environment." 1>&2
+	echo "" 1>&2
 	exit 1
 fi
 
@@ -43,6 +46,15 @@ fi
 
 # Include the environment specific variables.
 export DRUPAL_TI_SCRIPT_DIRS="$DRUPAL_TI_SCRIPT_DIR_BEFORE $DRUPAL_TI_SCRIPT_DIR $DRUPAL_TI_SCRIPT_DIR_AFTER"
+
+# In case the special '--include' flag was given, just include the given command with vars set.
+if [ "$CMD" = '--include' ]
+then
+	shift
+	SCRIPT="$1"
+	"$DRUPAL_TI_SCRIPT_DIR/utility/include-script.sh" "$SCRIPT"
+	exit 0
+fi
 
 # From here on in, we handle failures ourselves.
 set +e

--- a/runners/test/script.sh
+++ b/runners/test/script.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+test -f "test-include-success.txt" || exit 1
 cd $DRUPAL_TI_TESTS_DIR
 ./tests/run-tests.sh

--- a/tests/drupal-7/drupal_ti_test/scripts/test-include.sh
+++ b/tests/drupal-7/drupal_ti_test/scripts/test-include.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+touch test-include-success.txt

--- a/tests/drupal-8/drupal_ti_test/scripts/test-include.sh
+++ b/tests/drupal-8/drupal_ti_test/scripts/test-include.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+touch test-include-success.txt


### PR DESCRIPTION
Closes: #14

Support composer-manager by allowing to run custom script:

Example:

- drupal-ti --include scripts/composer-manager.sh

composer-manager.sh

```
#!/bin/bash

set -e $DRUPAL_TI_DEBUG

# Ensure the right Drupal version is installed.
# Note: This function is re-entrant.
drupal_ti_ensure_drupal

cd "$DRUPAL_TI_DRUPAL_DIR"

drush dl composer_manager --yes
drush pm-enable composer_manager --yes
drush composer-manager-init
```