### PR TITLE
#29: Add `drush site-set` after site installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ Example:
 ````
 
 Contributions are welcome.
+
+### Drush
+
+For your convenience the 'drush site-set' command is set for the Drupal installation, so any Drush commands triggered in your own scripts will be run against the test Drupal instance.

--- a/environments/drupal-7.sh
+++ b/environments/drupal-7.sh
@@ -6,6 +6,7 @@ function drupal_ti_install_drupal() {
 	drush --yes dl drupal-7 --drupal-project-rename=drupal
 	cd drupal
 	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes site-install testing --db-url="$DRUPAL_TI_DB_URL"
+	drush use $(pwd)#default
 }
 
 function drupal_ti_clear_caches() {

--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -6,6 +6,7 @@ function drupal_ti_install_drupal() {
 	git clone --depth 1 --branch 8.0.x http://git.drupal.org/project/drupal.git
 	cd drupal
 	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes -v site-install minimal --db-url="$DRUPAL_TI_DB_URL"
+	drush use $(pwd)#default
 }
 
 function drupal_ti_clear_caches() {


### PR DESCRIPTION
As per #29, although not creating a drush alias, just using 'drush site-set' (or the alias of said command).