### PR TITLE
#32: Added drupal driver and tests for Drupal 7.

### DIFF
--- a/tests/drupal-7/drupal_ti_test/tests/behat/behat.yml.dist
+++ b/tests/drupal-7/drupal_ti_test/tests/behat/behat.yml.dist
@@ -13,7 +13,9 @@ default:
       browser_name: "$DRUPAL_TI_BEHAT_BROWSER"
     Drupal\DrupalExtension:
       blackbox: ~
-      api_driver: "drush"
+      api_driver: "drupal"
       drush_driver: "drush"
+      drupal:
+        drupal_root: "$DRUPAL_TI_DRUPAL_DIR"
       drush:
         root: "$DRUPAL_TI_DRUPAL_DIR"

--- a/tests/drupal-7/drupal_ti_test/tests/behat/features/drupal.feature
+++ b/tests/drupal-7/drupal_ti_test/tests/behat/features/drupal.feature
@@ -1,0 +1,10 @@
+@api
+Feature: Drupal-specific steps
+  In order to prove that the drupal driver is working properly
+  As a developer
+  I need to be able to use the steps provided here
+
+  Scenario: drupal is bootstraped
+    Given I am logged in as a user with the "authenticated user" role
+    Then I should see "Log out"
+


### PR DESCRIPTION
As per #32 and #31.

Currently only does Drupal 7, and the test is super basic and could be improved, will probably do a bit more when I can, but about to run out the door.

D8 version just didn't work, possibly the drupal_root needs to be different, but it kept throwing errors.