### PR TITLE
Added setting a variable which is necessary for php 5.6

### DIFF
--- a/drupal-ti
+++ b/drupal-ti
@@ -50,6 +50,12 @@ fi
 # Include the environment specific variables.
 export DRUPAL_TI_SCRIPT_DIRS="$DRUPAL_TI_SCRIPT_DIR_BEFORE $DRUPAL_TI_SCRIPT_DIR $DRUPAL_TI_SCRIPT_DIR_AFTER"
 
+# Set necessary envrionment variable for some modules on 5.6 (like REST).
+if [ $(phpenv version-name) == '5.6' ]
+then
+	echo "always_populate_raw_post_data=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
+fi
+
 # In case a '--' command was given, just include the given command with vars set.
 if [[ "$CMD" == '--'* ]]
 then


### PR DESCRIPTION
I tried testing it with default_content and my fork, but seems like it's not just forking and adding your name to the composer gloabal require directive.

This setting can not be toggled yet, as you requested in the [comment](https://github.com/larowlan/default_content/pull/47#issuecomment-128287487).