### PR TITLE
Making a variable for the install profile that is used.

### DIFF
--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -5,7 +5,7 @@
 function drupal_ti_install_drupal() {
 	git clone --depth 1 --branch 8.0.x http://git.drupal.org/project/drupal.git
 	cd drupal
-	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes -v site-install minimal --db-url="$DRUPAL_TI_DB_URL"
+	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes -v site-install $DRUPAL_TI_INSTALL_PROFILE --db-url="$DRUPAL_TI_DB_URL"
 	drush use $(pwd)#default
 }
 


### PR DESCRIPTION
While working on https://github.com/stevector/template_mapper/pull/5 I found I needed to change the install profile being used. I know that drupal_ti has a mechanism to override functions like drupal_ti_install_drupal() however I could not get my overrides picked up. I'll work on solving that problem separately.

Instead, I forked drupal_ti and made a variable of the install profile. This PR is not ready to be merged yet because this variable needs a default value. I'm not sure of the best way to set that. Also if the variable is used here, it might belong in the drupal-7.sh file as well.