### PR TITLE
Issue #32: Added drupal driver and tests for Drupal 7 and 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,13 @@ env:
     #- DRUPAL_TI_ENVIRONMENT="drupal-7"
 
     # The installation profile to use:
+    #
+    # Note: This is customized for drupal-8 environment in
+    #       tests/drupal-8/drupal_ti_test/tests/drupal_ti/before/environments/drupal-8.sh.
+    #
+    # The reason is that behat strongly depends on a logout link being present,
+    # but minimal does not have one.
+    #
     #- DRUPAL_TI_INSTALL_PROFILE="testing"
 
     # Drupal specific variables.

--- a/tests/drupal-7/drupal_ti_test/tests/behat/behat.yml.dist
+++ b/tests/drupal-7/drupal_ti_test/tests/behat/behat.yml.dist
@@ -13,7 +13,9 @@ default:
       browser_name: "$DRUPAL_TI_BEHAT_BROWSER"
     Drupal\DrupalExtension:
       blackbox: ~
-      api_driver: "drush"
+      api_driver: "drupal"
       drush_driver: "drush"
+      drupal:
+        drupal_root: "$DRUPAL_TI_DRUPAL_DIR"
       drush:
         root: "$DRUPAL_TI_DRUPAL_DIR"

--- a/tests/drupal-7/drupal_ti_test/tests/behat/features/drupal.feature
+++ b/tests/drupal-7/drupal_ti_test/tests/behat/features/drupal.feature
@@ -1,0 +1,10 @@
+@api
+Feature: Drupal-specific steps
+  In order to prove that the drupal driver is working properly
+  As a developer
+  I need to be able to use the steps provided here
+
+  Scenario: drupal is bootstraped
+    Given I am logged in as a user with the "authenticated user" role
+    Then I should see "Log out"
+

--- a/tests/drupal-8/drupal_ti_test/tests/behat/behat.yml
+++ b/tests/drupal-8/drupal_ti_test/tests/behat/behat.yml
@@ -13,7 +13,9 @@ default:
       browser_name: firefox
     Drupal\DrupalExtension:
       blackbox: ~
-      api_driver: "drush"
+      api_driver: "drupal"
       drush_driver: "drush"
+      drupal:
+        drupal_root: "/Users/fabian/Sites/render-cache/"
       drush:
         root: "/Users/fabian/Sites/render-cache/"

--- a/tests/drupal-8/drupal_ti_test/tests/behat/behat.yml.dist
+++ b/tests/drupal-8/drupal_ti_test/tests/behat/behat.yml.dist
@@ -13,7 +13,9 @@ default:
       browser_name: firefox
     Drupal\DrupalExtension:
       blackbox: ~
-      api_driver: "drush"
+      api_driver: "drupal"
       drush_driver: "drush"
+      drupal:
+        drupal_root: "$DRUPAL_TI_DRUPAL_DIR"
       drush:
         root: "$DRUPAL_TI_DRUPAL_DIR"

--- a/tests/drupal-8/drupal_ti_test/tests/behat/composer.json
+++ b/tests/drupal-8/drupal_ti_test/tests/behat/composer.json
@@ -1,5 +1,6 @@
 {
   "require": {
-    "drupal/drupal-extension": "~3.0"
+    "drupal/drupal-extension": "~3.0",
+    "drupal/drupal-driver": "dev-master"
   }
 }

--- a/tests/drupal-8/drupal_ti_test/tests/behat/composer.lock
+++ b/tests/drupal-8/drupal_ti_test/tests/behat/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1f1455f2a9ec54028818d0ea1cd0e55a",
+    "hash": "826b31ab19e387ea34b8c4042cd2551b",
+    "content-hash": "5d086921f956945d63c0c85fb0d27be6",
     "packages": [
         {
             "name": "behat/behat",
@@ -150,12 +151,12 @@
             "version": "v1.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Behat/Mink.git",
+                "url": "https://github.com/minkphp/Mink.git",
                 "reference": "090900a0049c441f1e072bbd837db4079b2250c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Mink/zipball/090900a0049c441f1e072bbd837db4079b2250c5",
+                "url": "https://api.github.com/repos/minkphp/Mink/zipball/090900a0049c441f1e072bbd837db4079b2250c5",
                 "reference": "090900a0049c441f1e072bbd837db4079b2250c5",
                 "shasum": ""
             },
@@ -205,12 +206,12 @@
             "version": "v1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Behat/MinkBrowserKitDriver.git",
+                "url": "https://github.com/minkphp/MinkBrowserKitDriver.git",
                 "reference": "aed8f4a596b79014a75254c3e337511c33e38cbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/MinkBrowserKitDriver/zipball/aed8f4a596b79014a75254c3e337511c33e38cbd",
+                "url": "https://api.github.com/repos/minkphp/MinkBrowserKitDriver/zipball/aed8f4a596b79014a75254c3e337511c33e38cbd",
                 "reference": "aed8f4a596b79014a75254c3e337511c33e38cbd",
                 "shasum": ""
             },
@@ -319,12 +320,12 @@
             "version": "v1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Behat/MinkGoutteDriver.git",
+                "url": "https://github.com/minkphp/MinkGoutteDriver.git",
                 "reference": "2bf327b4166694ecaa8ae7f956cb6ae252ecf03e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/MinkGoutteDriver/zipball/2bf327b4166694ecaa8ae7f956cb6ae252ecf03e",
+                "url": "https://api.github.com/repos/minkphp/MinkGoutteDriver/zipball/2bf327b4166694ecaa8ae7f956cb6ae252ecf03e",
                 "reference": "2bf327b4166694ecaa8ae7f956cb6ae252ecf03e",
                 "shasum": ""
             },
@@ -371,12 +372,12 @@
             "version": "v1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Behat/MinkSelenium2Driver.git",
+                "url": "https://github.com/minkphp/MinkSelenium2Driver.git",
                 "reference": "8018fee80bf6573f909ece3e0dfc07d0eb352210"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/MinkSelenium2Driver/zipball/8018fee80bf6573f909ece3e0dfc07d0eb352210",
+                "url": "https://api.github.com/repos/minkphp/MinkSelenium2Driver/zipball/8018fee80bf6573f909ece3e0dfc07d0eb352210",
                 "reference": "8018fee80bf6573f909ece3e0dfc07d0eb352210",
                 "shasum": ""
             },
@@ -466,30 +467,40 @@
         },
         {
             "name": "drupal/drupal-driver",
-            "version": "v1.0.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhedstrom/DrupalDriver.git",
-                "reference": "955d235bb2a8e1dda1f5f43c0c2c8a31459563a2"
+                "reference": "7dfcbf3d5a84a2835f9803124338b8adbb8d93f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhedstrom/DrupalDriver/zipball/955d235bb2a8e1dda1f5f43c0c2c8a31459563a2",
-                "reference": "955d235bb2a8e1dda1f5f43c0c2c8a31459563a2",
+                "url": "https://api.github.com/repos/jhedstrom/DrupalDriver/zipball/7dfcbf3d5a84a2835f9803124338b8adbb8d93f1",
+                "reference": "7dfcbf3d5a84a2835f9803124338b8adbb8d93f1",
                 "shasum": ""
             },
             "require": {
-                "symfony/process": "~2.5"
+                "symfony/dependency-injection": "~2.6|~3.0",
+                "symfony/process": "~2.5|~3.0"
             },
             "require-dev": {
+                "drupal/coder": "~8.2.0",
+                "drush-ops/behat-drush-endpoint": "*",
+                "mockery/mockery": "0.9.4",
                 "phpspec/phpspec": "~2.0",
                 "phpunit/phpunit": "~4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Drupal\\Component": "src/",
-                    "Drupal\\Driver": "src/"
+                    "Drupal\\Driver": "src/",
+                    "Drupal\\Tests\\Driver": "tests/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -509,7 +520,7 @@
                 "test",
                 "web"
             ],
-            "time": "2014-11-07 22:04:58"
+            "time": "2015-12-07 19:45:18"
         },
         {
             "name": "drupal/drupal-extension",
@@ -631,12 +642,12 @@
             "target-dir": "Guzzle/Common",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/common.git",
+                "url": "https://github.com/Guzzle3/common.git",
                 "reference": "2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/common/zipball/2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc",
+                "url": "https://api.github.com/repos/Guzzle3/common/zipball/2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc",
                 "reference": "2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc",
                 "shasum": ""
             },
@@ -675,12 +686,12 @@
             "target-dir": "Guzzle/Http",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/http.git",
+                "url": "https://github.com/Guzzle3/http.git",
                 "reference": "1e8dd1e2ba9dc42332396f39fbfab950b2301dc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/http/zipball/1e8dd1e2ba9dc42332396f39fbfab950b2301dc5",
+                "url": "https://api.github.com/repos/Guzzle3/http/zipball/1e8dd1e2ba9dc42332396f39fbfab950b2301dc5",
                 "reference": "1e8dd1e2ba9dc42332396f39fbfab950b2301dc5",
                 "shasum": ""
             },
@@ -732,12 +743,12 @@
             "target-dir": "Guzzle/Parser",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/parser.git",
+                "url": "https://github.com/Guzzle3/parser.git",
                 "reference": "6874d171318a8e93eb6d224cf85e4678490b625c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/parser/zipball/6874d171318a8e93eb6d224cf85e4678490b625c",
+                "url": "https://api.github.com/repos/Guzzle3/parser/zipball/6874d171318a8e93eb6d224cf85e4678490b625c",
                 "reference": "6874d171318a8e93eb6d224cf85e4678490b625c",
                 "shasum": ""
             },
@@ -776,12 +787,12 @@
             "target-dir": "Guzzle/Stream",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/stream.git",
+                "url": "https://github.com/Guzzle3/stream.git",
                 "reference": "60c7fed02e98d2c518dae8f97874c8f4622100f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/stream/zipball/60c7fed02e98d2c518dae8f97874c8f4622100f0",
+                "url": "https://api.github.com/repos/Guzzle3/stream/zipball/60c7fed02e98d2c518dae8f97874c8f4622100f0",
                 "reference": "60c7fed02e98d2c518dae8f97874c8f4622100f0",
                 "shasum": ""
             },
@@ -887,12 +898,12 @@
             "target-dir": "Symfony/Component/BrowserKit",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/BrowserKit.git",
+                "url": "https://github.com/symfony/browser-kit.git",
                 "reference": "de6a5b6d09a67f5b53ce423a320b75afb335cca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/BrowserKit/zipball/de6a5b6d09a67f5b53ce423a320b75afb335cca0",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/de6a5b6d09a67f5b53ce423a320b75afb335cca0",
                 "reference": "de6a5b6d09a67f5b53ce423a320b75afb335cca0",
                 "shasum": ""
             },
@@ -942,12 +953,12 @@
             "target-dir": "Symfony/Component/ClassLoader",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/ClassLoader.git",
+                "url": "https://github.com/symfony/class-loader.git",
                 "reference": "b403af3d4fa3a2c3c926121c05042107e3a5b916"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ClassLoader/zipball/b403af3d4fa3a2c3c926121c05042107e3a5b916",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/b403af3d4fa3a2c3c926121c05042107e3a5b916",
                 "reference": "b403af3d4fa3a2c3c926121c05042107e3a5b916",
                 "shasum": ""
             },
@@ -992,12 +1003,12 @@
             "target-dir": "Symfony/Component/Config",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Config.git",
+                "url": "https://github.com/symfony/config.git",
                 "reference": "9282bb7f3251a95478a7198534577c02ab30b6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/9282bb7f3251a95478a7198534577c02ab30b6b6",
+                "url": "https://api.github.com/repos/symfony/config/zipball/9282bb7f3251a95478a7198534577c02ab30b6b6",
                 "reference": "9282bb7f3251a95478a7198534577c02ab30b6b6",
                 "shasum": ""
             },
@@ -1040,12 +1051,12 @@
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "https://github.com/symfony/console.git",
                 "reference": "d3bac228fd7a2aac9193e241b239880b3ba39a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/d3bac228fd7a2aac9193e241b239880b3ba39a10",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d3bac228fd7a2aac9193e241b239880b3ba39a10",
                 "reference": "d3bac228fd7a2aac9193e241b239880b3ba39a10",
                 "shasum": ""
             },
@@ -1097,12 +1108,12 @@
             "target-dir": "Symfony/Component/CssSelector",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/CssSelector.git",
+                "url": "https://github.com/symfony/css-selector.git",
                 "reference": "41953ad30ffc5cd710d106cf01eff79f6effa117"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/CssSelector/zipball/41953ad30ffc5cd710d106cf01eff79f6effa117",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/41953ad30ffc5cd710d106cf01eff79f6effa117",
                 "reference": "41953ad30ffc5cd710d106cf01eff79f6effa117",
                 "shasum": ""
             },
@@ -1148,12 +1159,12 @@
             "target-dir": "Symfony/Component/DependencyInjection",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/DependencyInjection.git",
+                "url": "https://github.com/symfony/dependency-injection.git",
                 "reference": "20bc8737876e4a2222101749b5547fd5acc24e30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/20bc8737876e4a2222101749b5547fd5acc24e30",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/20bc8737876e4a2222101749b5547fd5acc24e30",
                 "reference": "20bc8737876e4a2222101749b5547fd5acc24e30",
                 "shasum": ""
             },
@@ -1205,12 +1216,12 @@
             "target-dir": "Symfony/Component/DomCrawler",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/DomCrawler.git",
+                "url": "https://github.com/symfony/dom-crawler.git",
                 "reference": "9a67f1344e70a18e5d5e755ed442066351bed936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DomCrawler/zipball/9a67f1344e70a18e5d5e755ed442066351bed936",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/9a67f1344e70a18e5d5e755ed442066351bed936",
                 "reference": "9a67f1344e70a18e5d5e755ed442066351bed936",
                 "shasum": ""
             },
@@ -1258,12 +1269,12 @@
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
                 "reference": "697331d4ac78668cf6d21a2bb009b3faae92814f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/697331d4ac78668cf6d21a2bb009b3faae92814f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/697331d4ac78668cf6d21a2bb009b3faae92814f",
                 "reference": "697331d4ac78668cf6d21a2bb009b3faae92814f",
                 "shasum": ""
             },
@@ -1316,12 +1327,12 @@
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
+                "url": "https://github.com/symfony/filesystem.git",
                 "reference": "6f7c7e42f20ee200d8ac5d2ec1d2a524138305e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/6f7c7e42f20ee200d8ac5d2ec1d2a524138305e0",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6f7c7e42f20ee200d8ac5d2ec1d2a524138305e0",
                 "reference": "6f7c7e42f20ee200d8ac5d2ec1d2a524138305e0",
                 "shasum": ""
             },
@@ -1560,8 +1571,11 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "drupal/drupal-driver": 20
+    },
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": [],
     "platform-dev": []
 }

--- a/tests/drupal-8/drupal_ti_test/tests/behat/features/drupal.feature
+++ b/tests/drupal-8/drupal_ti_test/tests/behat/features/drupal.feature
@@ -1,0 +1,10 @@
+@api
+Feature: Drupal-specific steps
+  In order to prove that the drupal driver is working properly
+  As a developer
+  I need to be able to use the steps provided here
+
+  Scenario: drupal is bootstraped
+    Given I am logged in as a user with the "authenticated user" role
+    Then I should see "Log out"
+

--- a/tests/drupal-8/drupal_ti_test/tests/drupal_ti/before/environments/drupal-8.sh
+++ b/tests/drupal-8/drupal_ti_test/tests/drupal_ti/before/environments/drupal-8.sh
@@ -3,3 +3,7 @@
 # Drupal-8 environment variables.
 
 export DRUPAL_TI_SIMPLETEST_GROUP="drupal_ti_test_group";
+
+# Override the install profile for Drupal 8.
+# This is needed as behat does not work with minimal right now.
+export DRUPAL_TI_INSTALL_PROFILE="standard";


### PR DESCRIPTION
As per #32 and #31.

Adds usage of drupal-driver for Drupal 7 and 8.

For Drupal 8 the newest version of drupal-driver:dev-master needed to be used.

Also minimal profile does not have a logout link, so circumventing by using standard profile for now until https://github.com/jhedstrom/drupalextension/pull/131 or similar is fixed.

### Original report
Currently only does Drupal 7, and the test is super basic and could be improved, will probably do a bit more when I can, but about to run out the door.

D8 version just didn't work, possibly the drupal_root needs to be different, but it kept throwing errors.

Replaces #33.

This closes #32 and closes #31.