### PR TITLE
Default to Drush 8 for both Drupal 7 & 8 because dev-master now needs PHP 5.5+

### DIFF
--- a/environments/drupal-7.sh
+++ b/environments/drupal-7.sh
@@ -13,7 +13,7 @@ function drupal_ti_clear_caches() {
 	drush cc all
 }
 
-export DRUPAL_TI_DRUSH_VERSION="drush/drush:dev-master"
+export DRUPAL_TI_DRUSH_VERSION="drush/drush:8.*"
 export DRUPAL_TI_SIMPLETEST_FILE="scripts/run-tests.sh"
 export DRUPAL_TI_MODULES_PATH="sites/all/modules"
 export DRUPAL_TI_DRUPAL_BASE="$TRAVIS_BUILD_DIR/../drupal-7"

--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -13,7 +13,7 @@ function drupal_ti_clear_caches() {
 	drush cr
 }
 
-export DRUPAL_TI_DRUSH_VERSION="drush/drush:dev-master"
+export DRUPAL_TI_DRUSH_VERSION="drush/drush:8.*"
 export DRUPAL_TI_SIMPLETEST_FILE="core/scripts/run-tests.sh"
 export DRUPAL_TI_MODULES_PATH="modules"
 export DRUPAL_TI_DRUPAL_BASE="$TRAVIS_BUILD_DIR/../drupal-8"


### PR DESCRIPTION
We run the Panopoly tests on PHP 5.4, 5.5 & 5.6 - although, mostly through PHP 5.4 because we want to make sure we work with the lowest PHP version possible capable of running our tests.

Suddenly, tests started failing on PHP 5.4 because drush/drush:dev-master now requires PHP 5.5+:

http://docs.drush.org/en/master/install/#drupal-compatibility

In order for tests to continue working with PHP 5.4 (which is also the minimum for Drupal 8), we should default to installing Drush 8 for both Drupal 7 and 8.