### PR TITLE
Switch to drush 8.0.* because drush 8.1.0 has some problems with runserver.

### DIFF
--- a/environments/drupal-7.sh
+++ b/environments/drupal-7.sh
@@ -13,7 +13,7 @@ function drupal_ti_clear_caches() {
 	drush cc all
 }
 
-export DRUPAL_TI_DRUSH_VERSION="drush/drush:8.*"
+export DRUPAL_TI_DRUSH_VERSION="drush/drush:8.0.*"
 export DRUPAL_TI_SIMPLETEST_FILE="scripts/run-tests.sh"
 export DRUPAL_TI_MODULES_PATH="sites/all/modules"
 export DRUPAL_TI_DRUPAL_BASE="$TRAVIS_BUILD_DIR/../drupal-7"


### PR DESCRIPTION
This is to work around this issue in drush 8.1.0:

https://github.com/drush-ops/drush/issues/2157