### PR TITLE
Remove the "\s" (spaces) inside the regex

### DIFF
--- a/runners/simpletest/script.sh
+++ b/runners/simpletest/script.sh
@@ -15,5 +15,5 @@ fi
 cd "$DRUPAL_TI_DRUPAL_DIR"
 { php "$DRUPAL_TI_SIMPLETEST_FILE" --php $(which php) "${ARGS[@]}" || echo "1 fails"; } | tee /tmp/simpletest-result.txt
 
-egrep -i "([1-9]+ fail[s]?\s)|(Fatal error)|([1-9]+ exception[s]?\s)" /tmp/simpletest-result.txt && exit 1
+egrep -i "([1-9]+ fail[s]?)|(Fatal error)|([1-9]+ exception[s]?)" /tmp/simpletest-result.txt && exit 1
 exit 0


### PR DESCRIPTION
I can't figure out why we would need theses `\s`.
Actually, if the script returns "1 fails" only, the script will exit with 0 (means success) because the regex would not catch "1 fails", it would only catch "1 fails " (with a space at the end).

So we have two choice here:
1. Add a space at the end of `echo "1 fails "`
2. Remove the `\s` in the regex

I chose the second option because it smell less bad and because I don't understand the usefulness of theses.

What do you think ?
Thanks