### PR TITLE
Use composer config to set module as path repository

### DIFF
--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -15,6 +15,23 @@ function drupal_ti_clear_caches() {
 	drush cr
 }
 
+#
+# Ensures that the module is linked into the Drupal code base.
+#
+function drupal_ti_ensure_module_linked() {
+	# Ensure we are in the right directory.
+	cd "$DRUPAL_TI_DRUPAL_DIR"
+
+	# This function is re-entrant.
+	if [ -L "$DRUPAL_TI_MODULES_PATH/$DRUPAL_TI_MODULE_NAME" ]
+	then
+		return
+	fi
+
+	composer config repositories.$DRUPAL_TI_MODULE_NAME path $TRAVIS_BUILD_DIR
+	composer require drupal/$DRUPAL_TI_MODULE_NAME
+}
+
 export DRUPAL_TI_DRUSH_VERSION="drush/drush:8.0.*"
 export DRUPAL_TI_SIMPLETEST_FILE="core/scripts/run-tests.sh"
 export DRUPAL_TI_MODULES_PATH="modules"

--- a/tests/drupal-8/drupal_ti_test/composer.json
+++ b/tests/drupal-8/drupal_ti_test/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "drupal/drupal_ti_test",
+    "type": "drupal-module",
+    "description": "Drupal Travis Integration - Test module.",
+    "homepage": "https://github.com/LionsAd/drupal_ti",
+    "license": "GPL-2.0+",
+    "repositories": [
+        {
+            "type": "composer",
+            "url":  "https://packages.drupal.org/8"
+        }
+    ],
+    "require": {
+      "drupal/core": "~8"
+    }
+}


### PR DESCRIPTION
This overrides `drupal_ti_ensure_module_linked` in Drupal 8 to use Composer to add the repository as a `path` repository setting. This will let Composer do the symlink and install dependencies.