### PR TITLE
Expose option to switch Drush version on Drupal 8 env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,9 @@ env:
     # The environment to use, supported are: drupal-7, drupal-8
     #- DRUPAL_TI_ENVIRONMENT="drupal-7"
 
+    # The drush version to use, by default: drush/drush:8.0.*
+    # - DRUPAL_TI_DRUSH_VERSION="drush/drush:~9.0"
+
     # The installation profile to use:
     #
     # Note: This is customized for drupal-8 environment in

--- a/.travis.yml.dist
+++ b/.travis.yml.dist
@@ -41,6 +41,9 @@ env:
     # The environment to use, supported are: drupal-7, drupal-8
     - DRUPAL_TI_ENVIRONMENT="drupal-7"
 
+    # The drush version to use, by default: drush/drush:8.0.*
+    # - DRUPAL_TI_DRUSH_VERSION="drush/drush:~9.0"
+
     # The installation profile to use:
     #- DRUPAL_TI_INSTALL_PROFILE="testing"
 

--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -34,7 +34,10 @@ function drupal_ti_ensure_module_linked() {
 	composer require drupal/$DRUPAL_TI_MODULE_NAME *@dev
 }
 
-export DRUPAL_TI_DRUSH_VERSION="drush/drush:8.0.*"
+if [ -z "$DRUPAL_TI_DRUSH_VERSION" ]
+then
+  export DRUPAL_TI_DRUSH_VERSION="drush/drush:8.0.*"
+fi
 export DRUPAL_TI_SIMPLETEST_FILE="core/scripts/run-tests.sh"
 export DRUPAL_TI_DRUPAL_BASE="$TRAVIS_BUILD_DIR/../drupal-8"
 export DRUPAL_TI_DRUPAL_DIR="$DRUPAL_TI_DRUPAL_BASE/drupal"


### PR DESCRIPTION
Probleme/Motivation
====

For now, it's impossible to specify an other version of drush than `drush/drush:8.0.*`

Resolution
====

Expose the already existing `DRUPAL_TI_DRUSH_VERSION`.
It only works for D8.4+ env. Drush 9 isn't mean to works for Drupal 7.