### PR TITLE
Expose option to add extra dependencies via composer

### DIFF
--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -8,7 +8,7 @@ function drupal_ti_install_drupal() {
 	composer install
 
 	# Add extra composer dependencies when required.
-	if [ -z "$COMPOSER_EXTRA_DEPENDENCIES" ]
+	if [ -n "$COMPOSER_EXTRA_DEPENDENCIES" ]
 	then
 		composer require "$COMPOSER_EXTRA_DEPENDENCIES" --no-interaction
 	fi

--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -10,7 +10,7 @@ function drupal_ti_install_drupal() {
 	# Add extra composer dependencies when required.
 	if [ -z "$COMPOSER_EXTRA_DEPENDENCIES" ]
 	then
-		composer require "$DRUPAL_TI_INSTALL_PROFILE" --no-interaction
+		composer require "$COMPOSER_EXTRA_DEPENDENCIES" --no-interaction
 	fi
 
 	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes -v site-install "$DRUPAL_TI_INSTALL_PROFILE" --db-url="$DRUPAL_TI_DB_URL"

--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -6,6 +6,13 @@ function drupal_ti_install_drupal() {
 	git clone --depth 1 --branch "$DRUPAL_TI_CORE_BRANCH" http://git.drupal.org/project/drupal.git
 	cd drupal
 	composer install
+
+	# Add extra composer dependencies when required.
+	if [ -z "$COMPOSER_EXTRA_DEPENDENCIES" ]
+	then
+		composer require "$DRUPAL_TI_INSTALL_PROFILE" --no-interaction
+	fi
+
 	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes -v site-install "$DRUPAL_TI_INSTALL_PROFILE" --db-url="$DRUPAL_TI_DB_URL"
 	drush use $(pwd)#default
 }


### PR DESCRIPTION
Probleme/Motivation
====

It's impossible to add extra dependencies before running installation of Drupal.
But some modules (Eg. [Backerymails](https://www.drupal.org/project/backerymails) & plenty others such as [Paragraphs](https://www.drupal.org/project/paragraphs), ... ) required extra dependencies to run. 

Resolution
====

Adding a new option `$COMPOSER_EXTRA_DEPENDENCIES` which is a string of extra dependencies to add after the initial composer install.

Tested & works in this Travis jobs: https://travis-ci.org/antistatique/drupal-backerymails/jobs/339798294