### PR TITLE
Fix COMPOSER_EXTRA_DEPENDENCIES to allow multiples dependencies

### DIFF
--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -10,7 +10,7 @@ function drupal_ti_install_drupal() {
 	# Add extra composer dependencies when required.
 	if [ -n "$COMPOSER_EXTRA_DEPENDENCIES" ]
 	then
-		composer require "$COMPOSER_EXTRA_DEPENDENCIES" --no-interaction
+		composer require $COMPOSER_EXTRA_DEPENDENCIES --no-interaction
 	fi
 
 	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes -v site-install "$DRUPAL_TI_INSTALL_PROFILE" --db-url="$DRUPAL_TI_DB_URL"


### PR DESCRIPTION
It seems the previous version of `COMPOSER_EXTRA_DEPENDENCIES` from #110 didn't allow multiple dependencies.

Eg. when you set
```
- COMPOSER_EXTRA_DEPENDENCIES="symfony/finder:^3.4 symfony/process:^3.4"
```

it crash because it's used as following
```
composer require "symfony/finder:^3.4 symfony/process:^3.4" --no-interaction
```

By removing the quotes it then became

```
composer require symfony/finder:^3.4 symfony/process:^3.4 --no-interaction
```

And it will then works as design.