### PR TITLE
Fix composer 1.8.x - drupal-ti: command not found

### DIFF
--- a/.travis.yml.dist
+++ b/.travis.yml.dist
@@ -29,7 +29,7 @@ env:
     # see: https://github.com/drush-ops/drush#install---composer
     - PATH="$PATH:$HOME/.composer/vendor/bin"
     # force composer 1.8+ to use a specific folder as home
-    #- export COMPOSER_HOME="$HOME/.composer/"
+    - COMPOSER_HOME="$HOME/.composer/"
 
     # Configuration variables.
     - DRUPAL_TI_MODULE_NAME="[[[FILL THIS OUT]]]"


### PR DESCRIPTION
Will close #116 