### PR TITLE
Update default to 8.7

### DIFF
--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -58,7 +58,7 @@ export DRUPAL_TI_DIST_DIR="$HOME/.dist"
 export PATH="$DRUPAL_TI_DIST_DIR/usr/bin:$PATH"
 if [ -z "$DRUPAL_TI_CORE_BRANCH" ]
 then
-	export DRUPAL_TI_CORE_BRANCH="8.1.x"
+	export DRUPAL_TI_CORE_BRANCH="8.7.x"
 fi
 
 # The default folder for modules changes in 8.3.x.


### PR DESCRIPTION
Drupal 8.1 was deprecated quite some time ago and has security vulnerabilities and should not be used. There is also a lot of bug fixes for testing.