### PR TITLE
Drush does not use .php extension after 9.x

### DIFF
--- a/environments/drupal-7.sh
+++ b/environments/drupal-7.sh
@@ -5,7 +5,7 @@
 function drupal_ti_install_drupal() {
 	drush --yes dl drupal-7 --drupal-project-rename=drupal
 	cd drupal
-	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes site-install "$DRUPAL_TI_INSTALL_PROFILE" --db-url="$DRUPAL_TI_DB_URL"
+	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush --yes site-install "$DRUPAL_TI_INSTALL_PROFILE" --db-url="$DRUPAL_TI_DB_URL"
 	drush use $(pwd)#default
 }
 

--- a/environments/drupal-8.sh
+++ b/environments/drupal-8.sh
@@ -19,7 +19,7 @@ function drupal_ti_install_drupal() {
 		composer require $COMPOSER_EXTRA_DEPENDENCIES --no-interaction
 	fi
 
-	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush.php --yes -v site-install "$DRUPAL_TI_INSTALL_PROFILE" --db-url="$DRUPAL_TI_DB_URL"
+	php -d sendmail_path=$(which true) ~/.composer/vendor/bin/drush --yes -v site-install "$DRUPAL_TI_INSTALL_PROFILE" --db-url="$DRUPAL_TI_DB_URL"
 	drush use $(pwd)#default
 }
 


### PR DESCRIPTION
After Drush 9.x the `./composer/vendor/bin/drush.php` was dropped. 8.x versions of Drush had both the `drush.php` and the `drush` versions. Since Drupal_TI requires at least 8.0.* there should be no backward compatibility problem.