### PR TITLE
Set chromedriver version based on chrome version

### DIFF
--- a/.travis.yml.dist
+++ b/.travis.yml.dist
@@ -76,6 +76,10 @@ env:
     # Set DRUPAL_TI_BEHAT_DRIVER to "selenium" to use "firefox" or "chrome" here.
     - DRUPAL_TI_BEHAT_DRIVER="phantomjs"
     - DRUPAL_TI_BEHAT_BROWSER="firefox"
+    # Pin to a specific version of Chrome if needed.
+    #- DRUPAL_TI_BEHAT_CHROME_URL="http://www.slimjetbrowser.com/chrome/files/80.0.3987.149/google-chrome-stable_current_amd64.deb"
+    # For Chrome versions starting with 73, the correct version of chromedriver will be downloaded automatically, but it can be overridden here for older versions.
+    #- DRUPAL_TI_BEHAT_CHROMEDRIVER_VERSION="80.0.3987.106"
 
     # PHPUnit specific commandline arguments.
     - DRUPAL_TI_PHPUNIT_ARGS=""

--- a/functions/behat.sh
+++ b/functions/behat.sh
@@ -123,20 +123,22 @@ function drupal_ti_ensure_chrome_driver() {
 		return
 	fi
 
+	drupal_ti_ensure_chrome
 	drupal_ti_ensure_bin_dir
 	cd $DRUPAL_TI_BIN_DIR
 
+	# Get the installed Chrome version number.
+	CHROME_VERSION=$(google-chrome --version | sed -r 's/[^0-9]+([0-9]+\.[0-9]+\.[0-9]+).*/\1/g')
 	# @todo Move to defaults API.
 	if [ -z "$DRUPAL_TI_BEHAT_CHROMEDRIVER_VERSION" ]
 	then
-		DRUPAL_TI_BEHAT_CHROMEDRIVER_VERSION=$(wget http://chromedriver.storage.googleapis.com/LATEST_RELEASE -qO-)
+		DRUPAL_TI_BEHAT_CHROMEDRIVER_VERSION=$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION -qO-)
 	fi
 
 	wget http://chromedriver.storage.googleapis.com/$DRUPAL_TI_BEHAT_CHROMEDRIVER_VERSION/chromedriver_linux64.zip
 	unzip chromedriver_linux64.zip
 	rm -f chromedriver_linux64.zip
 	chmod a+x chromedriver
-	drupal_ti_ensure_chrome
 
 	touch "$TRAVIS_BUILD_DIR/../drupal_ti-chrome-driver-installed"
 }


### PR DESCRIPTION
Since Chrome version 73, [Chromedriver versions are synchronized with Chrome versions](https://chromedriver.chromium.org/downloads); a major release of Chromedriver only works with the matching major release of Chrome. The behat.sh script can choose the correct version automatically, but we can still allow pinning to specific versions of Chromedriver if needed.